### PR TITLE
fix: correct typo "Paper Rview" → "Paper Review" in section guide index

### DIFF
--- a/research-paper-writing/SKILL.md
+++ b/research-paper-writing/SKILL.md
@@ -61,7 +61,7 @@ Load only the needed section file:
 - Method: `references/method.md`
 - Experiments: `references/experiments.md`
 - Conclusion: `references/conclusion.md`
-- Paper review (Paper Rview): `references/paper-review.md`
+- Paper review (Paper Review): `references/paper-review.md`
 - Paragraph clarity source: `references/does-my-writing-flow-source.md`
 - Example bank index: `references/examples/index.md`
 


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: Line 64 of `research-paper-writing/SKILL.md` reads `Paper Rview` — a typo for `Paper Review` in the section guide index.

**Evidence**: The line `- Paper review (Paper Rview): \`references/paper-review.md\`` contains a clear misspelling; the surrounding label is `Paper review` (correct), but the parenthetical display name drops the `e` in `Review`.

**Fix**: Changed `Paper Rview` to `Paper Review` on line 64.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"R01","fingerprint":"sha256:684ef202760f37ae5be48546d2a2f7bc2bba0cf6165d0c2b78a6824ef7a5df24"}]}
nlpm-metadata-end -->